### PR TITLE
Fix Bug - Unable to Decode Empty String

### DIFF
--- a/Sources/AvroDecoder.swift
+++ b/Sources/AvroDecoder.swift
@@ -115,7 +115,7 @@ open class AvroDecoder {
     open func decodeBytes() -> [UInt8]? {
         if let sizeLong = decodeLong() {
             let size = Int(sizeLong)
-            if size <= Int(bytes.count) && size != 0 {
+            if size <= Int(bytes.count) && size >= 0 {
                 let tmp = bytes[0..<size]
                 bytes.removeSubrange(0..<size)
                 return [UInt8](tmp)


### PR DESCRIPTION
Currently the `AvroDecoder` returns an `.avroInvalidValue` if attempting to decode an empty string (`""`). As per the Avro specs, empty string is a valid response and should be decoded. 

Rather than guarding against `size !=0`, we should ensure that the byte array falls within the range of `0` to `bytes.count`. (i.e. `size >= 0`)